### PR TITLE
updated SPI API & impl to match current WiringPi version

### DIFF
--- a/wiringPi/wiringPiSPI.c
+++ b/wiringPi/wiringPiSPI.c
@@ -1,7 +1,7 @@
 /*
  * wiringPiSPI.c:
  *	Simplified SPI access routines
- *	Copyright (c) 2012 Gordon Henderson
+ *	Copyright (c) 2012-2015 Gordon Henderson
  ***********************************************************************
  * This file is part of wiringPi:
  *	https://projects.drogon.net/raspberry-pi/wiringpi/
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <asm/ioctl.h>
 #include <linux/spi/spidev.h>
 
 #include "wiringPi.h"
@@ -38,11 +39,10 @@
 // The SPI bus parameters
 //	Variables as they need to be passed as pointers later on
 
-const static char       *spiDev0  = "/dev/spidev0.0" ;
-const static char       *spiDev1  = "/dev/spidev0.1" ;
-const static uint8_t     spiMode  = 0 ;
-const static uint8_t     spiBPW   = 8 ;
-const static uint16_t    spiDelay = 0 ;
+static const char       *spiDev0  = "/dev/spidev0.0" ;
+static const char       *spiDev1  = "/dev/spidev0.1" ;
+static const uint8_t     spiBPW   = 8 ;
+static const uint16_t    spiDelay = 0 ;
 
 static uint32_t    spiSpeeds [2] ;
 static int         spiFds [2] ;
@@ -75,6 +75,11 @@ int wiringPiSPIDataRW (int channel, unsigned char *data, int len)
 
   channel &= 1 ;
 
+// Mentioned in spidev.h but not used in the original kernel documentation
+//	test program )-:
+
+  memset (&spi, 0, sizeof (spi)) ;
+
   spi.tx_buf        = (unsigned long)data ;
   spi.rx_buf        = (unsigned long)data ;
   spi.len           = len ;
@@ -87,16 +92,17 @@ int wiringPiSPIDataRW (int channel, unsigned char *data, int len)
 
 
 /*
- * wiringPiSPISetup:
- *	Open the SPI device, and set it up, etc.
+ * wiringPiSPISetupMode:
+ *	Open the SPI device, and set it up, with the mode, etc.
  *********************************************************************************
  */
 
-int wiringPiSPISetup (int channel, int speed)
+int wiringPiSPISetupMode (int channel, int speed, int mode)
 {
   int fd ;
 
-  channel &= 1 ;
+  mode    &= 3 ;	// Mode is 0, 1, 2 or 3
+  channel &= 1 ;	// Channel is 0 or 1
 
   if ((fd = open (channel == 0 ? spiDev0 : spiDev1, O_RDWR)) < 0)
     return wiringPiFailure (WPI_ALMOST, "Unable to open SPI device: %s\n", strerror (errno)) ;
@@ -105,12 +111,10 @@ int wiringPiSPISetup (int channel, int speed)
   spiFds    [channel] = fd ;
 
 // Set SPI parameters.
-//	Why are we reading it afterwriting it? I've no idea, but for now I'm blindly
-//	copying example code I've seen online...
 
-  if (ioctl (fd, SPI_IOC_WR_MODE, &spiMode)         < 0)
+  if (ioctl (fd, SPI_IOC_WR_MODE, &mode)            < 0)
     return wiringPiFailure (WPI_ALMOST, "SPI Mode Change failure: %s\n", strerror (errno)) ;
-  
+
   if (ioctl (fd, SPI_IOC_WR_BITS_PER_WORD, &spiBPW) < 0)
     return wiringPiFailure (WPI_ALMOST, "SPI BPW Change failure: %s\n", strerror (errno)) ;
 
@@ -118,4 +122,16 @@ int wiringPiSPISetup (int channel, int speed)
     return wiringPiFailure (WPI_ALMOST, "SPI Speed Change failure: %s\n", strerror (errno)) ;
 
   return fd ;
+}
+
+
+/*
+ * wiringPiSPISetup:
+ *	Open the SPI device, and set it up, etc. in the default MODE 0
+ *********************************************************************************
+ */
+
+int wiringPiSPISetup (int channel, int speed)
+{
+  return wiringPiSPISetupMode (channel, speed, 0) ;
 }

--- a/wiringPi/wiringPiSPI.h
+++ b/wiringPi/wiringPiSPI.h
@@ -28,6 +28,7 @@ extern "C" {
 
 int wiringPiSPIGetFd  (int channel) ;
 int wiringPiSPIDataRW (int channel, unsigned char *data, int len) ;
+int wiringPiSPISetupMode (int channel, int speed, int mode) ;
 int wiringPiSPISetup  (int channel, int speed) ;
 
 #ifdef __cplusplus


### PR DESCRIPTION
This changeset updates the SPI implementation to match the current WiringPi codebase and primarily adds support for the `wiringPiSPISetupMode (int channel, int speed, int mode)` setup function where the user can provide a custom mode parameter.