### PR TITLE
Small problem fixes and code formatting improvements 

### DIFF
--- a/build
+++ b/build
@@ -17,21 +17,21 @@ check_make_ok() {
 
 if [ x$1 = "xclean" ]; then
   cd wiringPi
-  echo -n "wiringPi:   "	; make clean
+  echo -n "wiringPi:   " ; make clean
   cd ../devLib
-  echo -n "DevLib:     "	; make clean
+  echo -n "DevLib:     " ; make clean
   cd ../gpio
-  echo -n "gpio:       "	; make clean
+  echo -n "gpio:       " ; make clean
   cd ../examples
-  echo -n "Examples:   "	; make clean
+  echo -n "Examples:   " ; make clean
   cd Gertboard
-  echo -n "Gertboard:  "	; make clean
+  echo -n "Gertboard:  " ; make clean
   cd ../PiFace
-  echo -n "PiFace:     "	; make clean
+  echo -n "PiFace:     " ; make clean
   cd ../q2w
-  echo -n "Quick2Wire: "	; make clean
+  echo -n "Quick2Wire: " ; make clean
   cd ../PiGlow
-  echo -n "PiGlow:     "	; make clean
+  echo -n "PiGlow:     " ; make clean
   exit
 fi
 
@@ -45,48 +45,47 @@ if [ x$1 = "xuninstall" ]; then
   exit
 fi
 
+echo "wiringPi Build script"
+echo "====================="
+echo
 
-  echo "wiringPi Build script"
-  echo "====================="
-  echo
-
-  echo
-  echo "WiringPi Library"
-  cd wiringPi
-  ${PFX}make uninstall
-  if [ x$1 = "xstatic" ]; then
-    make static
-    check_make_ok
-    ${PFX}make install-static
-  else
-    make
-    check_make_ok
-    ${PFX}make install
-  fi
+echo
+echo "WiringPi Library"
+cd wiringPi
+${PFX}make uninstall
+if [ x$1 = "xstatic" ]; then
+  make static
   check_make_ok
-
-  echo
-  echo "WiringPi Devices Library"
-  cd ../devLib
-  ${PFX}make uninstall
-  if [ x$1 = "xstatic" ]; then
-    make static
-    check_make_ok
-    ${PFX}make install-static
-  else
-    make
-    check_make_ok
-    ${PFX}make install
-  fi
-  check_make_ok
-
-  echo
-  echo "GPIO Utility"
-  cd ../gpio
+  ${PFX}make install-static
+else
   make
   check_make_ok
   ${PFX}make install
+fi
+check_make_ok
+
+echo
+echo "WiringPi Devices Library"
+cd ../devLib
+${PFX}make uninstall
+if [ x$1 = "xstatic" ]; then
+  make static
   check_make_ok
+  ${PFX}make install-static
+else
+  make
+  check_make_ok
+  ${PFX}make install
+fi
+check_make_ok
+
+echo
+echo "GPIO Utility"
+cd ../gpio
+make
+check_make_ok
+${PFX}make install
+check_make_ok
 
 # echo
 # echo "Examples"

--- a/build
+++ b/build
@@ -54,11 +54,11 @@ echo "WiringPi Library"
 cd wiringPi
 ${PFX}make uninstall
 if [ x$1 = "xstatic" ]; then
-  make static
+  make -j `nproc` static
   check_make_ok
   ${PFX}make install-static
 else
-  make
+  make -j `nproc`
   check_make_ok
   ${PFX}make install
 fi
@@ -69,11 +69,11 @@ echo "WiringPi Devices Library"
 cd ../devLib
 ${PFX}make uninstall
 if [ x$1 = "xstatic" ]; then
-  make static
+  make -j `nproc` static
   check_make_ok
   ${PFX}make install-static
 else
-  make
+  make -j `nproc`
   check_make_ok
   ${PFX}make install
 fi
@@ -82,7 +82,7 @@ check_make_ok
 echo
 echo "GPIO Utility"
 cd ../gpio
-make
+make -j `nproc`
 check_make_ok
 ${PFX}make install
 check_make_ok

--- a/wiringPi/boardtype_friendlyelec.c
+++ b/wiringPi/boardtype_friendlyelec.c
@@ -9,86 +9,86 @@ const char* allwinner_tempfile = "/sys/class/thermal/thermal_zone0/temp";
 #define LOGE printf
 
 BoardHardwareInfo gAllBoardHardwareInfo[] = {
-    {"MINI6410", -1, S3C6410_COMMON, "S3C6410_Board",""},
-    {"MINI210", -1, S5PV210_COMMON, "S5PV210_Board",""},
-    {"TINY4412", -1, S5P4412_COMMON, "S5P4412_Board",""},
-    {"mini2451", 0, S3C2451_COMMON, "S3C2451_Board", ""},
+    {"MINI6410", -1, S3C6410_COMMON, "S3C6410_Board", ""},
+    {"MINI210",  -1, S5PV210_COMMON, "S5PV210_Board", ""},
+    {"TINY4412", -1, S5P4412_COMMON, "S5P4412_Board", ""},
+    {"mini2451",  0, S3C2451_COMMON, "S3C2451_Board", ""},
 
     //s5p4418
-    {"nanopi2", 0, NanoPi2, "NanoPi2",""},
-    {"nanopi2", 1, NanoPC_T2, "NanoPC-T2",""},
-    {"nanopi2", 2, NanoPi_S2, "NanoPi-S2",""},
-    {"nanopi2", 3, Smart4418, "Smart4418",""},
-    {"nanopi2", 4, NanoPi2_Fire, "NanoPi2-Fire",""},
-    {"nanopi2", 5, NanoPi_M2, "NanoPi-M2",""},
-    {"nanopi2", 7, NanoPi_M2A, "NanoPi-M2A",""},
-    {"nanopi2", 0x103, Smart4418SDK, "Smart4418SDK",""},
+    {"nanopi2",     0, NanoPi2,      "NanoPi2",      ""},
+    {"nanopi2",     1, NanoPC_T2,    "NanoPC-T2",    ""},
+    {"nanopi2",     2, NanoPi_S2,    "NanoPi-S2",    ""},
+    {"nanopi2",     3, Smart4418,    "Smart4418",    ""},
+    {"nanopi2",     4, NanoPi2_Fire, "NanoPi2-Fire", ""},
+    {"nanopi2",     5, NanoPi_M2,    "NanoPi-M2",    ""},
+    {"nanopi2",     7, NanoPi_M2A,   "NanoPi-M2A",   ""},
+    {"nanopi2", 0x103, Smart4418SDK, "Smart4418SDK", ""},
 
     //s5p6818
-    {"nanopi3", 1, NanoPC_T3, "NanoPC-T3",""},
-    {"nanopi3", 2, NanoPi_M3B, "NanoPi-M3B",""},
-    {"nanopi3", 3, Smart6818, "Smart6818",""},
-    {"nanopi3", 4, NanoPC_T3T, "NanoPC-T3T",""},
-    {"nanopi3", 5, NanoPi_Fire3, "NanoPi-Fire3",""},
-    {"nanopi3", 7, NanoPi_M3, "NanoPi-M3",""},
+    {"nanopi3", 1, NanoPC_T3,    "NanoPC-T3",    ""},
+    {"nanopi3", 2, NanoPi_M3B,   "NanoPi-M3B",   ""},
+    {"nanopi3", 3, Smart6818,    "Smart6818",    ""},
+    {"nanopi3", 4, NanoPC_T3T,   "NanoPC-T3T",   ""},
+    {"nanopi3", 5, NanoPi_Fire3, "NanoPi-Fire3", ""},
+    {"nanopi3", 7, NanoPi_M3,    "NanoPi-M3",    ""},
 
     //allwinner h3
     // kernel 3.x
-    {"sun8i", 0, NanoPi_M1, "NanoPi-M1", "0(0)"},
-    {"sun8i", 0, NanoPi_NEO, "NanoPi-NEO", "1(0)"},
-    {"sun8i", 0, NanoPi_NEO_Air, "NanoPi-NEO-Air", "2(0)"},
-    {"sun8i", 0, NanoPi_M1_Plus, "NanoPi-M1-Plus", "3(0)"},
-    {"sun8i", 0, NanoPi_Duo, "NanoPi-Duo", "4(0)"},
+    {"sun8i", 0, NanoPi_M1,       "NanoPi-M1",       "0(0)"},
+    {"sun8i", 0, NanoPi_NEO,      "NanoPi-NEO",      "1(0)"},
+    {"sun8i", 0, NanoPi_NEO_Air,  "NanoPi-NEO-Air",  "2(0)"},
+    {"sun8i", 0, NanoPi_M1_Plus,  "NanoPi-M1-Plus",  "3(0)"},
+    {"sun8i", 0, NanoPi_Duo,      "NanoPi-Duo",      "4(0)"},
     {"sun8i", 0, NanoPi_NEO_Core, "NanoPi-NEO-Core", "5(0)"},
-    {"sun8i", 0, NanoPi_K1, "NanoPi-K1", "6(0)"},
-    {"sun8i", 0, NanoPi_Hero, "NanoPi-Hero", "7(0)"},
-    {"sun8i", 0, NanoPi_Duo2, "NanoPi-Duo2", "8(0)"},
-    {"sun8i", 0, NanoPi_R1, "NanoPi-R1", "9(0)"},
+    {"sun8i", 0, NanoPi_K1,       "NanoPi-K1",       "6(0)"},
+    {"sun8i", 0, NanoPi_Hero,     "NanoPi-Hero",     "7(0)"},
+    {"sun8i", 0, NanoPi_Duo2,     "NanoPi-Duo2",     "8(0)"},
+    {"sun8i", 0, NanoPi_R1,       "NanoPi-R1",       "9(0)"},
 
     // kernel 4.x
-    {"Allwinnersun8iFamily", 0, NanoPi_M1, "NanoPi-M1", "0(0)"},
-    {"Allwinnersun8iFamily", 0, NanoPi_NEO, "NanoPi-NEO", "1(0)"},
-    {"Allwinnersun8iFamily", 0, NanoPi_NEO_Air, "NanoPi-NEO-Air", "2(0)"},
-    {"Allwinnersun8iFamily", 0, NanoPi_M1_Plus, "NanoPi-M1-Plus", "3(0)"},
-    {"Allwinnersun8iFamily", 0, NanoPi_Duo, "NanoPi-Duo", "4(0)"},
+    {"Allwinnersun8iFamily", 0, NanoPi_M1,       "NanoPi-M1",       "0(0)"},
+    {"Allwinnersun8iFamily", 0, NanoPi_NEO,      "NanoPi-NEO",      "1(0)"},
+    {"Allwinnersun8iFamily", 0, NanoPi_NEO_Air,  "NanoPi-NEO-Air",  "2(0)"},
+    {"Allwinnersun8iFamily", 0, NanoPi_M1_Plus,  "NanoPi-M1-Plus",  "3(0)"},
+    {"Allwinnersun8iFamily", 0, NanoPi_Duo,      "NanoPi-Duo",      "4(0)"},
     {"Allwinnersun8iFamily", 0, NanoPi_NEO_Core, "NanoPi-NEO-Core", "5(0)"},
-    {"Allwinnersun8iFamily", 0, NanoPi_K1, "NanoPi-K1", "6(0)"},
-    {"Allwinnersun8iFamily", 0, NanoPi_Hero, "NanoPi-Hero", "7(0)"},
-    {"Allwinnersun8iFamily", 0, NanoPi_Duo2, "NanoPi-Duo2", "8(0)"},
-    {"Allwinnersun8iFamily", 0, NanoPi_R1, "NanoPi-R1", "9(0)"},
+    {"Allwinnersun8iFamily", 0, NanoPi_K1,       "NanoPi-K1",       "6(0)"},
+    {"Allwinnersun8iFamily", 0, NanoPi_Hero,     "NanoPi-Hero",     "7(0)"},
+    {"Allwinnersun8iFamily", 0, NanoPi_Duo2,     "NanoPi-Duo2",     "8(0)"},
+    {"Allwinnersun8iFamily", 0, NanoPi_R1,       "NanoPi-R1",       "9(0)"},
 
     // a64
     {"sun50iw1p1", 0, NanoPi_A64, "NanoPi-A64", "0"},
 
     //allwinner h5
     // kernel 3.x
-    {"sun50iw2", 4, NanoPi_NEO2, "NanoPi-NEO2", "1(0)"},
-    {"sun50iw2", 4, NanoPi_M1_Plus2, "NanoPi-M1-Plus2", "3(0)"}, 
+    {"sun50iw2", 4, NanoPi_NEO2,      "NanoPi-NEO2",      "1(0)"},
+    {"sun50iw2", 4, NanoPi_M1_Plus2,  "NanoPi-M1-Plus2",  "3(0)"},
     {"sun50iw2", 4, NanoPi_NEO_Plus2, "NanoPi-NEO-Plus2", "2(0)"},
     {"sun50iw2", 4, NanoPi_NEO_Core2, "NanoPi-NEO-Core2", "0(0)"},
-    {"sun50iw2", 4, NanoPi_K1_Plus, "NanoPi-K1-Plus", "4(0)"},
+    {"sun50iw2", 4, NanoPi_K1_Plus,   "NanoPi-K1-Plus",   "4(0)"},
 
     // kernel 4.x
-    {"Allwinnersun50iw2Family", 4, NanoPi_NEO2, "NanoPi-NEO2", "1(0)"},
-    {"Allwinnersun50iw2Family", 4, NanoPi_M1_Plus2, "NanoPi-M1-Plus2", "3(0)"},
+    {"Allwinnersun50iw2Family", 4, NanoPi_NEO2,      "NanoPi-NEO2",      "1(0)"},
+    {"Allwinnersun50iw2Family", 4, NanoPi_M1_Plus2,  "NanoPi-M1-Plus2",  "3(0)"},
     {"Allwinnersun50iw2Family", 4, NanoPi_NEO_Plus2, "NanoPi-NEO-Plus2", "2(0)"},
     {"Allwinnersun50iw2Family", 4, NanoPi_NEO_Core2, "NanoPi-NEO-Core2", "0(0)"},
-    {"Allwinnersun50iw2Family", 4, NanoPi_K1_Plus, "NanoPi-K1-Plus", "4(0)"},
+    {"Allwinnersun50iw2Family", 4, NanoPi_K1_Plus,   "NanoPi-K1-Plus",   "4(0)"},
 
     //k2
     {"Amlogic", 0, NanoPi_K2, "NanoPi-K2", ""},
 
     //t4
-    {"nanopi4", 0, NanoPC_T4, "NanoPC-T4",""},
-    {"nanopi4", 1, NanoPi_M4, "NanoPi-M4",""},
-    {"nanopi4", 2, NanoPC_T4, "NanoPC-T4",""},
-    {"nanopi4", 4, NanoPi_NEO4, "NanoPi-NEO4",""},
+    {"nanopi4", 0, NanoPC_T4,   "NanoPC-T4",   ""},
+    {"nanopi4", 1, NanoPi_M4,   "NanoPi-M4",   ""},
+    {"nanopi4", 2, NanoPC_T4,   "NanoPC-T4",   ""},
+    {"nanopi4", 4, NanoPi_NEO4, "NanoPi-NEO4", ""},
 };
 
-static int getFieldValueInCpuInfo(char* hardware, int hardwareMaxLen, char* revision, int revisionMaxLen )
+static int getFieldValueInCpuInfo(char* hardware, int hardwareMaxLen, char* revision, int revisionMaxLen)
 {
     int n,i,j;
-    char lineUntrim[1024], line[1024],line2[1024],*p,*p2;
+    char lineUntrim[1024], line[1024], line2[1024], *p, *p2;
     FILE *f;
     int isGotHardware = 0;
     int isGotRevision = 0;
@@ -104,16 +104,19 @@ static int getFieldValueInCpuInfo(char* hardware, int hardwareMaxLen, char* revi
         if(!fgets(lineUntrim, sizeof(lineUntrim), f)) {
             break;
         } else {
-            j=0;
-            for(i=0; i<strlen(lineUntrim);i++) {
-                if (lineUntrim[i] == ' ' || lineUntrim[i] == '\t' || lineUntrim[i] == '\r' || lineUntrim[i] == '\n') {
+            j = 0;
+            for (i = 0; i < strlen(lineUntrim); i++) {
+                if (lineUntrim[i] == ' '
+                        || lineUntrim[i] == '\t'
+                        || lineUntrim[i] == '\r'
+                        || lineUntrim[i] == '\n') {
                 } else {
                     line[j++]=lineUntrim[i];
                 }
             }
             line[j] = 0x00;
             n = strlen(line);
-            if (n>0) {
+            if (n > 0) {
                 //LOGD("LINE: %s\n", line);
                 #define GetKeyValue(isGot,valP,keyName,buff,buffLen) \
                 if (isGot==0) { \
@@ -129,8 +132,8 @@ static int getFieldValueInCpuInfo(char* hardware, int hardwareMaxLen, char* revi
                         } \
                     } \
                 }
-                GetKeyValue(isGotHardware,p,"Hardware",hardware,hardwareMaxLen);
-                GetKeyValue(isGotRevision,p2,"Revision",revision,revisionMaxLen);
+                GetKeyValue(isGotHardware, p, "Hardware", hardware, hardwareMaxLen);
+                GetKeyValue(isGotRevision, p2, "Revision", revision, revisionMaxLen);
 
                 if (isGotHardware == 1 && isGotRevision == 1) {
                     break;
@@ -146,7 +149,7 @@ static int getFieldValueInCpuInfo(char* hardware, int hardwareMaxLen, char* revi
 static int getAllwinnerBoardID(char* boardId, int boardIdMaxLen )
 {
     int n,i,j;
-    char lineUntrim[1024], line[1024],*p;
+    char lineUntrim[1024], line[1024], *p;
     const char* sunxi_board_id_fieldname = "sunxi_board_id";
     FILE *f;
     int ret = -1;
@@ -160,16 +163,19 @@ static int getAllwinnerBoardID(char* boardId, int boardIdMaxLen )
         if(!fgets(lineUntrim, sizeof(lineUntrim), f)) {
             break;
         } else {
-            j=0;
-            for(i=0; i<strlen(lineUntrim);i++) {
-                if (lineUntrim[i] == ' ' || lineUntrim[i] == '\t' || lineUntrim[i] == '\r' || lineUntrim[i] == '\n') {
+            j = 0;
+            for (i = 0; i < strlen(lineUntrim); i++) {
+                if (lineUntrim[i] == ' '
+                        || lineUntrim[i] == '\t'
+                        || lineUntrim[i] == '\r'
+                        || lineUntrim[i] == '\n') {
                 } else {
                     line[j++]=lineUntrim[i];
                 }
             }
             line[j] = 0x00;
             n = strlen(line);
-            if (n>0) {
+            if (n > 0) {
                 //LOGD("LINE: %s\n", line);
                 if (p = strtok(line, ":")) {
                     if (strncasecmp(p, sunxi_board_id_fieldname, strlen(sunxi_board_id_fieldname)) == 0) {
@@ -210,12 +216,15 @@ int getBoardType(BoardHardwareInfo** retBoardInfo) {
     const char* h3 = "sun8i";
     const char* h5 = "sun50iw2";
     const char* h3_kernel4 = "Allwinnersun8iFamily";
-        const char* h5_kernel4 = "Allwinnersun50iw2Family";
+    const char* h5_kernel4 = "Allwinnersun50iw2Family";
 
     //a64 and amlogic, only check hardware
-    if (strncasecmp(hardware, a64, strlen(a64)) == 0 || strncasecmp(hardware, amlogic, strlen(amlogic)) == 0) {
-        for (i=0; i<(sizeof(gAllBoardHardwareInfo)/sizeof(BoardHardwareInfo)); i++) {
-            if (strncasecmp(gAllBoardHardwareInfo[i].kernelHardware, hardware, strlen(gAllBoardHardwareInfo[i].kernelHardware)) == 0) {
+    if (strncasecmp(hardware, a64, strlen(a64)) == 0
+            || strncasecmp(hardware, amlogic, strlen(amlogic)) == 0) {
+        for (i = 0; i < (sizeof(gAllBoardHardwareInfo)/sizeof(BoardHardwareInfo)); i++) {
+            if (strncasecmp(gAllBoardHardwareInfo[i].kernelHardware,
+                            hardware,
+                            strlen(gAllBoardHardwareInfo[i].kernelHardware)) == 0) {
                 if (retBoardInfo != 0) {
                     *retBoardInfo = &gAllBoardHardwareInfo[i];
                 }
@@ -231,11 +240,15 @@ int getBoardType(BoardHardwareInfo** retBoardInfo) {
         int ret = getAllwinnerBoardID(allwinnerBoardID, sizeof(allwinnerBoardID));
         if (ret == 0) {
             //LOGD("got boardid: %s\n", allwinnerBoardID);
-            for (i=0; i<(sizeof(gAllBoardHardwareInfo)/sizeof(BoardHardwareInfo)); i++) {
+            for (i = 0; i < (sizeof(gAllBoardHardwareInfo)/sizeof(BoardHardwareInfo)); i++) {
                 //LOGD("\t{{ enum, start compare[%d]: %s <--> %s\n", i, gAllBoardHardwareInfo[i].kernelHardware, hardware);
-                if (strncasecmp(gAllBoardHardwareInfo[i].kernelHardware, hardware, strlen(gAllBoardHardwareInfo[i].kernelHardware)) == 0) {
+                if (strncasecmp(gAllBoardHardwareInfo[i].kernelHardware,
+                                hardware,
+                                strlen(gAllBoardHardwareInfo[i].kernelHardware)) == 0) {
                     //LOGD("\t\tMATCH %s\n", hardware);
-                    if (strncasecmp(gAllBoardHardwareInfo[i].allwinnerBoardID, allwinnerBoardID, strlen(gAllBoardHardwareInfo[i].allwinnerBoardID)) == 0) {
+                    if (strncasecmp(gAllBoardHardwareInfo[i].allwinnerBoardID,
+                                    allwinnerBoardID,
+                                    strlen(gAllBoardHardwareInfo[i].allwinnerBoardID)) == 0) {
                         if (retBoardInfo != 0) {
                             *retBoardInfo = &gAllBoardHardwareInfo[i];
                         }
@@ -264,7 +277,7 @@ int getBoardType(BoardHardwareInfo** retBoardInfo) {
     iRev = strtol(revision2, NULL, 16);
 
     // other, check hardware and revision
-    for (i=0; i<(sizeof(gAllBoardHardwareInfo)/sizeof(BoardHardwareInfo)); i++) {
+    for (i = 0; i < (sizeof(gAllBoardHardwareInfo)/sizeof(BoardHardwareInfo)); i++) {
         if (strncasecmp(gAllBoardHardwareInfo[i].kernelHardware, hardware, strlen(gAllBoardHardwareInfo[i].kernelHardware)) == 0) {
             if (gAllBoardHardwareInfo[i].kernelRevision == -1
                     || gAllBoardHardwareInfo[i].kernelRevision == iRev

--- a/wiringPi/boardtype_friendlyelec.c
+++ b/wiringPi/boardtype_friendlyelec.c
@@ -87,7 +87,7 @@ BoardHardwareInfo gAllBoardHardwareInfo[] = {
 
 static int getFieldValueInCpuInfo(char* hardware, int hardwareMaxLen, char* revision, int revisionMaxLen)
 {
-    int n,i,j;
+    unsigned long n, i, j;
     char lineUntrim[1024], line[1024], line2[1024], *p, *p2;
     FILE *f;
     int isGotHardware = 0;
@@ -148,7 +148,7 @@ static int getFieldValueInCpuInfo(char* hardware, int hardwareMaxLen, char* revi
 
 static int getAllwinnerBoardID(char* boardId, int boardIdMaxLen )
 {
-    int n,i,j;
+    unsigned long n, i, j;
     char lineUntrim[1024], line[1024], *p;
     const char* sunxi_board_id_fieldname = "sunxi_board_id";
     FILE *f;
@@ -273,7 +273,7 @@ int getBoardType(BoardHardwareInfo** retBoardInfo) {
 
     char revision2[255];
     sprintf(revision2, "0x%s", revision);
-    int iRev;
+    long iRev;
     iRev = strtol(revision2, NULL, 16);
 
     // other, check hardware and revision

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -1680,21 +1680,21 @@ struct wiringPiNodeStruct *wiringPiNewNode(int pinBase, int numPins) {
             (void)wiringPiFailure(WPI_FATAL, "wiringPiNewNode: Pin %d overlaps with existing definition\n", pin);
 
     node = (struct wiringPiNodeStruct *) calloc(sizeof (struct wiringPiNodeStruct), 1); // calloc zeros
-    if (node == NULL)
+    if (node == NULL) {
         (void)wiringPiFailure(WPI_FATAL, "wiringPiNewNode: Unable to allocate memory: %s\n", strerror(errno));
-
-    node->pinBase = pinBase;
-    node->pinMax = pinBase + numPins - 1;
-    node->pinMode = pinModeDummy;
-    node->pullUpDnControl = pullUpDnControlDummy;
-    node->digitalRead = digitalReadDummy;
-    node->digitalWrite = digitalWriteDummy;
-    node->pwmWrite = pwmWriteDummy;
-    node->analogRead = analogReadDummy;
-    node->analogWrite = analogWriteDummy;
-    node->next = wiringPiNodes;
-    wiringPiNodes = node;
-
+    } else {
+        node->pinBase = pinBase;
+        node->pinMax = pinBase + numPins - 1;
+        node->pinMode = pinModeDummy;
+        node->pullUpDnControl = pullUpDnControlDummy;
+        node->digitalRead = digitalReadDummy;
+        node->digitalWrite = digitalWriteDummy;
+        node->pwmWrite = pwmWriteDummy;
+        node->analogRead = analogReadDummy;
+        node->analogWrite = analogWriteDummy;
+        node->next = wiringPiNodes;
+        wiringPiNodes = node;
+    }
     return node;
 }
 

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -134,6 +134,10 @@ struct wiringPiNodeStruct *wiringPiNodes = NULL;
 #define GPIO_PWM          (BCM2708_PERI_BASE + 0x0020C000)
 
 #define PAGE_SIZE  (4*1024)
+// Since BLOCK_SIZE is defined in /usr/include/linux/fs.h:
+#ifdef BLOCK_SIZE
+#undef BLOCK_SIZE
+#endif
 #define BLOCK_SIZE (4*1024)
 
 // PWM

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -1517,10 +1517,13 @@ int getAlt(int pin) {
         pin = pinToGpio [pin];
     else if (wiringPiMode == WPI_MODE_PHYS)
         pin = physToGpio[pin];
-    else if (wiringPiMode == WPI_MODE_GPIO)    //pin = pinTobcm[pin]; 
-        pin = pin;
-    else return 0;
-
+    else if (wiringPiMode == WPI_MODE_GPIO) {
+        //pin = pinTobcm[pin];
+        // pin = pin;
+        // Nothing
+    } else {
+        return 0;
+    }
     if (-1 == pin) {
         printf("[%s:L%d] the pin:%d  mode: %d is invaild,please check it over!\n", __func__, __LINE__, pin, wiringPiMode);
         return -1;
@@ -1545,9 +1548,13 @@ int getAltSilence(int pin) {
         pin = pinToGpio [pin];
     else if (wiringPiMode == WPI_MODE_PHYS)
         pin = physToGpio[pin];
-    else if (wiringPiMode == WPI_MODE_GPIO)    //pin = pinTobcm[pin]; 
-        pin = pin;
-    else return 0;
+    else if (wiringPiMode == WPI_MODE_GPIO) {
+        // pin = pinTobcm[pin];
+        // pin = pin;
+        // Nothing
+    } else {
+        return 0;
+    }
 
     if (-1 == pin) {
         return -1;
@@ -1803,10 +1810,13 @@ void pullUpDnControl(int pin, int pud) {
             pin = pinToGpio [pin];
         else if (wiringPiMode == WPI_MODE_PHYS)
             pin = physToGpio[pin];
-        else if (wiringPiMode == WPI_MODE_GPIO)
+        else if (wiringPiMode == WPI_MODE_GPIO) {
             // pin = pinTobcm[pin]; 
-            pin = pin;
-        else return;
+            // pin = pin;
+            // Nothing
+        } else {
+            return;
+        }
         if (wiringPiDebug)
             printf("%s,%d,pin:%d\n", __func__, __LINE__, pin);
 
@@ -1879,7 +1889,7 @@ int digitalRead(int pin) {
 		    }
 	    } else if (wiringPiMode == WPI_MODE_GPIO) {
 		    // pin = pinTobcm[pin]; 
-        pin = pin;
+            // pin = pin;
 
 		    if (wiringPiDebug) {
 			    printf(">>> pinTobcm[pin] ret %d\n", pin);
@@ -1902,7 +1912,6 @@ int digitalRead(int pin) {
 int digitalReadSilence(int pin) {
     char c;
     struct wiringPiNodeStruct *node = wiringPiNodes;
-    int oldPin = pin;
 
     if (pinToGpio == 0 || physToGpio == 0) {
         return 0;
@@ -1924,8 +1933,8 @@ int digitalReadSilence(int pin) {
         } else if (wiringPiMode == WPI_MODE_PHYS) {
             pin = physToGpio[pin];
         } else if (wiringPiMode == WPI_MODE_GPIO) {
-        // pin = pinTobcm[pin]; 
-        pin = pin;
+            // pin = pinTobcm[pin];
+            // pin = pin;
             // Nothing
         } else {
             return LOW;
@@ -1992,7 +2001,8 @@ void digitalWrite(int pin, int value) {
             pin = physToGpio[pin];
         else if (wiringPiMode == WPI_MODE_GPIO) {
             // pin = pinTobcm[pin];
-            pin = pin;
+            // pin = pin;
+            // Nothing
         }
         else return;
         if (-1 == pin) {

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -1854,24 +1854,23 @@ int digitalRead(int pin) {
         return 0;
     }
 
+    if (pin == 0 && wiringPiMode == WPI_MODE_GPIO_SYS) {
+        //printf("%d %s,%d invalid pin,please check it over.\n",pin,__func__, __LINE__);
+        return 0;
+    }
     if (pin > 0 && pin < MAX_PIN_COUNT) {
         if (wiringPiMode == WPI_MODE_GPIO_SYS) { // Sys mode
 		    if (wiringPiDebug) {
 			    printf("in digitalRead, wiringPiMode == WPI_MODE_GPIO_SYS\n");
 		    }
-		    if (pin == 0) {
-			    //printf("%d %s,%d invalid pin,please check it over.\n",pin,__func__, __LINE__);
-			    return 0;
-		    }
-
-        //TODO: fix me
-        /*
-		    if (syspin[pin] == -1) {
-			    //printf("%d %s,%d invalid pin,please check it over.\n",pin,__func__, __LINE__);
-			    return 0;
-		    }
-        */
-		    if (sysFds [pin] == -1) {
+            //TODO: fix me
+            /*
+            if (syspin[pin] == -1) {
+                //printf("%d %s,%d invalid pin,please check it over.\n",pin,__func__, __LINE__);
+                return 0;
+            }
+            */
+            if (sysFds [pin] == -1) {
 			    if (wiringPiDebug)
 				    printf("pin %d sysFds -1.%s,%d\n", pin, __func__, __LINE__);
 			    return LOW;
@@ -1921,11 +1920,12 @@ int digitalReadSilence(int pin) {
         return 0;
     }
 
+    if (pin == 0 && wiringPiMode == WPI_MODE_GPIO_SYS) {
+        return 0;
+    }
+
     if (pin > 0 && pin < MAX_PIN_COUNT) {
         if (wiringPiMode == WPI_MODE_GPIO_SYS) { // Sys mode
-            if (pin == 0) {
-                return 0;
-            }
             if (sysFds [pin] == -1) {
                 return LOW;
             }

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -127,14 +127,14 @@ struct wiringPiNodeStruct *wiringPiNodes = NULL;
 //	that I can find )-:
 
 #define BCM2708_PERI_BASE                      0x20000000
-#define GPIO_PADS  (BCM2708_PERI_BASE + 0x00100000)
-#define CLOCK_BASE  (BCM2708_PERI_BASE + 0x00101000)
-#define GPIO_BASE  (BCM2708_PERI_BASE + 0x00200000)
-#define GPIO_TIMER  (BCM2708_PERI_BASE + 0x0000B000)
-#define GPIO_PWM  (BCM2708_PERI_BASE + 0x0020C000)
+#define GPIO_PADS         (BCM2708_PERI_BASE + 0x00100000)
+#define CLOCK_BASE        (BCM2708_PERI_BASE + 0x00101000)
+#define GPIO_BASE         (BCM2708_PERI_BASE + 0x00200000)
+#define GPIO_TIMER        (BCM2708_PERI_BASE + 0x0000B000)
+#define GPIO_PWM          (BCM2708_PERI_BASE + 0x0020C000)
 
 #define PAGE_SIZE  (4*1024)
-#define BLOCK_SIZE  (4*1024)
+#define BLOCK_SIZE (4*1024)
 
 // PWM
 //	Word offsets into the PWM control region
@@ -149,7 +149,7 @@ struct wiringPiNodeStruct *wiringPiNodes = NULL;
 //	Clock regsiter offsets
 
 #define PWMCLK_CNTL 40
-#define PWMCLK_DIV 41
+#define PWMCLK_DIV  41
 
 #define PWM0_MS_MODE    0x0080  // Run in MS mode
 #define PWM0_USEFIFO    0x0020  // Data from FIFO
@@ -170,15 +170,15 @@ struct wiringPiNodeStruct *wiringPiNodes = NULL;
 // Timer
 //	Word offsets
 
-#define TIMER_LOAD (0x400 >> 2)
-#define TIMER_VALUE (0x404 >> 2)
-#define TIMER_CONTROL (0x408 >> 2)
-#define TIMER_IRQ_CLR (0x40C >> 2)
-#define TIMER_IRQ_RAW (0x410 >> 2)
+#define TIMER_LOAD     (0x400 >> 2)
+#define TIMER_VALUE    (0x404 >> 2)
+#define TIMER_CONTROL  (0x408 >> 2)
+#define TIMER_IRQ_CLR  (0x40C >> 2)
+#define TIMER_IRQ_RAW  (0x410 >> 2)
 #define TIMER_IRQ_MASK (0x414 >> 2)
-#define TIMER_RELOAD (0x418 >> 2)
-#define TIMER_PRE_DIV (0x41C >> 2)
-#define TIMER_COUNTER (0x420 >> 2)
+#define TIMER_RELOAD   (0x418 >> 2)
+#define TIMER_PRE_DIV  (0x41C >> 2)
+#define TIMER_COUNTER  (0x420 >> 2)
 
 // Locals to hold pointers to the hardware
 
@@ -194,31 +194,30 @@ static volatile uint32_t *timerIrqRaw;
 
 /*add for BananaPro by LeMaker team*/
 // for mmap BananaPro 
-#define MAX_PIN_NUM  (0x40)  //64
+#define MAX_PIN_NUM  (0x40)  // 64
 #define SUNXI_GPIO_BASE (0x01C20800)
 #define MAP_SIZE (4096*2)
 #define MAP_MASK (MAP_SIZE - 1)
 //sunxi_pwm
 //#define SUNXI_PWM_BASE (0x01c20e00)
-#define SUNXI_PWM_BASE (0x01c21400)
-#define SUNXI_PWM_CTRL_REG  (SUNXI_PWM_BASE)
-#define SUNXI_PWM_CH0_PERIOD  (SUNXI_PWM_BASE + 0x4)
-#define SUNXI_PWM_CH1_PERIOD  (SUNXI_PWM_BASE + 0x8)
+#define SUNXI_PWM_BASE                 (0x01c21400)
+#define SUNXI_PWM_CTRL_REG         (SUNXI_PWM_BASE)
+#define SUNXI_PWM_CH0_PERIOD (SUNXI_PWM_BASE + 0x4)
+#define SUNXI_PWM_CH1_PERIOD (SUNXI_PWM_BASE + 0x8)
 
-#define SUNXI_PWM_CH0_EN   (1 << 4)
-#define SUNXI_PWM_CH0_ACT_STA  (1 << 5)
+#define SUNXI_PWM_CH0_EN          (1 << 4)
+#define SUNXI_PWM_CH0_ACT_STA     (1 << 5)
 #define SUNXI_PWM_SCLK_CH0_GATING (1 << 6)
-#define SUNXI_PWM_CH0_MS_MODE  (1 << 7) //pulse mode
-#define SUNXI_PWM_CH0_PUL_START  (1 << 8)
+#define SUNXI_PWM_CH0_MS_MODE     (1 << 7) // pulse mode
+#define SUNXI_PWM_CH0_PUL_START   (1 << 8)
 
-#define SUNXI_PWM_CH1_EN   (1 << 19)
-#define SUNXI_PWM_CH1_ACT_STA  (1 << 20)
+#define SUNXI_PWM_CH1_EN          (1 << 19)
+#define SUNXI_PWM_CH1_ACT_STA     (1 << 20)
 #define SUNXI_PWM_SCLK_CH1_GATING (1 << 21)
-#define SUNXI_PWM_CH1_MS_MODE  (1 << 22) //pulse mode
-#define SUNXI_PWM_CH1_PUL_START  (1 << 23)
+#define SUNXI_PWM_CH1_MS_MODE     (1 << 22) // pulse mode
+#define SUNXI_PWM_CH1_PUL_START   (1 << 23)
 
-
-#define PWM_CLK_DIV_120          0
+#define PWM_CLK_DIV_120  0
 #define PWM_CLK_DIV_180  1
 #define PWM_CLK_DIV_240  2
 #define PWM_CLK_DIV_360  3
@@ -230,12 +229,12 @@ static volatile uint32_t *timerIrqRaw;
 #define PWM_CLK_DIV_72K  12
 
 #define GPIO_PADS_BP  (0x00100000)
-#define CLOCK_BASE_BP  (0x00101000)
+#define CLOCK_BASE_BP (0x00101000)
 //	addr should 4K*n
 //	#define GPIO_BASE_BP		(SUNXI_GPIO_BASE)
 #define GPIO_BASE_BP  (0x01C20000)
-#define GPIO_TIMER_BP  (0x0000B000)
-#define GPIO_PWM_BP  (0x01C21000)  //need 4k*n
+#define GPIO_TIMER_BP (0x0000B000)
+#define GPIO_PWM_BP   (0x01C21000)  // need 4k*n
 
 static int wiringPinMode = WPI_MODE_UNINITIALISED;
 int wiringPiCodes = FALSE;
@@ -278,7 +277,6 @@ static int sysFds [MAX_PIN_COUNT] ={
 
 //static void (*isrFunctions [64])(void);
 
-
 static int upDnConvert[3] = {7, 7, 5};
 
 static int *pinToGpio = 0;
@@ -308,169 +306,153 @@ static int *syspin = 0;
 
 // wPi number to /sys/gpio number
 static int pinToGpio_m1 [MAX_PIN_COUNT] ={
-    0, 6, // 0, 1
-    2, 3, // 2, 3
-    200, 201, // 4  5
-    1, 203, // 6, 7
-    12, 11, // 8, 9
-    67, 17, //10,11
-    64, 65, //12,13
-    66, 198, //14,15
-    199, -1, //16,17
-    -1, -1, //18,19
-    -1, 20, //20,21
-    21, 8, //22,23
-    13, 9, //24,25
-    7, 16, //26,27
-    15, 14, //28,29
-    19, 18, //30,31
-
-    4, 5, // 32, 33 Debug UART pins
+    0,     6,  //  0,  1
+    2,     3,  //  2,  3
+    200, 201,  //  4,  5
+    1,   203,  //  6,  7
+    12,   11,  //  8,  9
+    67,   17,  // 10, 11
+    64,   65,  // 12, 13
+    66,  198,  // 14, 15
+    199,  -1,  // 16, 17
+    -1,   -1,  // 18, 19
+    -1,   20,  // 20, 21
+    21,    8,  // 22, 23
+    13,    9,  // 24, 25
+    7,    16,  // 26, 27
+    15,   14,  // 28, 29
+    19,   18,  // 30, 31
+    4, 5,      // 32, 33 Debug UART pins
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // ... 47
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // ... 63
-
     /* 64~73 */
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 };
 
 // wPi number to /sys/gpio number
 static int pinToGpio_neo [MAX_PIN_COUNT] ={
-    0,        //0
-   /* 24 Pin */
-   6, 2,   //1, 2
-   3, 200,   //3, 4
-   201, 1,   //5, 6
-   203, 12, //7, 8
-   11,  67, //9, 10
-   -1,  64,   //11, 12
-   65,  66,  //13, 14
-   198,  199,  //15, 16
-   4, 5,  //17, 18
-   17, -1,   //19, 20
-   -1, 1,    //21, 22
-   -1, -1,   //23, 24
-
-   /* 12 Pin */
-   -1, -1,   //25, 26
-   -1, -1,   //27, 28
-   -1, -1,   //29, 30
-   -1, -1,   //31, 32
-   -1, -1,   //33, 34
-   -1, -1,   //35, 36
-
-   /* UART0 Tx,Rx */
-   -1, -1,     //37, 38
-
+    0,         // 0
+    /* 24 Pin */
+    6,     2,  //  1,  2
+    3,   200,  //  3,  4
+    201,   1,  //  5,  6
+    203,  12,  //  7,  8
+    11,   67,  //  9, 10
+    -1,   64,  // 11, 12
+    65,   66,  // 13, 14
+    198, 199,  // 15, 16
+    4,     5,  // 17, 18
+    17,   -1,  // 19, 20
+    -1,    1,  // 21, 22
+    -1,   -1,  // 23, 24
+    /* 12 Pin */
+    -1, -1,   // 25, 26
+    -1, -1,   // 27, 28
+    -1, -1,   // 29, 30
+    -1, -1,   // 31, 32
+    -1, -1,   // 33, 34
+    -1, -1,   // 35, 36
+    /* UART0 Tx, Rx */
+    -1, -1,   // 37, 38
     /* 39~63 */
-   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-
-   /* 64~73 */
-   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    /* 64~73 */
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 };
 
 
 // wPi number to /sys/gpio number
 static int pinToGpio_duo [MAX_PIN_COUNT] ={
-   16,       //0
- /* 32 Pin */
-   -1, 14,   //1, 2
-   13, -1,   //3, 4
-   -1, -1,   //5, 6
-   15, 198,   //7, 8
-   199, -1,   //9, 10
-   -1, 12,   //11, 12
-   11, 4,   //13, 14
-   5, 203,   //15, 16
-   -1,363,   //17, 18
-   -1, -1,   //19, 20
-   -1, -1,  //21, 22
-   -1, -1,  //23, 24
-   -1, -1,   //25, 26
-   -1, -1,   //27, 28
-   -1, -1,   //29, 30
-   -1, -1,   //31, 32
-   /* ---------nanopi duo end----------- */
-
-    -1, -1,   //33, 34
-    -1, -1,   //35, 36
-
+    16,       // 0
+    /* 32 Pin */
+    -1,  14,  //  1,  2
+    13,  -1,  //  3,  4
+    -1,  -1,  //  5,  6
+    15, 198,  //  7,  8
+    199, -1,  //  9, 10
+    -1,  12,  // 11, 12
+    11,   4,  // 13, 14
+     5, 203,  // 15, 16
+    -1, 363,  // 17, 18
+    -1, -1,   // 19, 20
+    -1, -1,   // 21, 22
+    -1, -1,   // 23, 24
+    -1, -1,   // 25, 26
+    -1, -1,   // 27, 28
+    -1, -1,   // 29, 30
+    -1, -1,   // 31, 32
+    /* ---------nanopi duo end----------- */
+    -1, -1,   // 33, 34
+    -1, -1,   // 35, 36
     /* UART0 Tx,Rx */
-    -1, -1,     //37, 38
-
+    -1, -1,   // 37, 38
     /* 39~63 */
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-
     /* 64~73 */
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 };
 
 // wPi number to /sys/gpio number
 static int pinToGpio_duo2 [MAX_PIN_COUNT] ={
-    16,       //0
- /* 32 Pin */
-   -1, 14,   //1, 2
-   13, -1,   //3, 4
-   -1, -1,   //5, 6
-   15,198,   //7, 8
-   -1,199,   //9, 10
-   -1, 12,   //11, 12
-   11,  4,   //13, 14
-    5,203,   //15, 16
-   -1,363,   //17, 18
-   -1, -1,   //19, 20
-   -1, -1,  //21, 22
-   -1, -1,  //23, 24
-   -1, -1,   //25, 26
-   -1, -1,   //27, 28
-   -1, -1,   //29, 30
-   -1, -1,   //31, 32
-   /* ---------nanopi duo end----------- */
-
-    -1, -1,   //33, 34
-    -1, -1,   //35, 36
-
+    16,       // 0
+    /* 32 Pin */
+    -1,  14,  //  1,  2
+    13,  -1,  //  3,  4
+    -1,  -1,  //  5,  6
+    15, 198,  //  7,  8
+    -1, 199,  //  9, 10
+    -1,  12,  // 11, 12
+    11,   4,  // 13, 14
+     5, 203,  // 15, 16
+    -1, 363,  // 17, 18
+    -1, -1,   // 19, 20
+    -1, -1,   // 21, 22
+    -1, -1,   // 23, 24
+    -1, -1,   // 25, 26
+    -1, -1,   // 27, 28
+    -1, -1,   // 29, 30
+    -1, -1,   // 31, 32
+    /* ---------nanopi duo end----------- */
+    -1, -1,  // 33, 34
+    -1, -1,  // 35, 36
     /* UART0 Tx,Rx */
-    -1, -1,     //37, 38
-
+    -1, -1,  // 37, 38
     /* 39~63 */
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-
     /* 64~73 */
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 };
 
 // wPi number to /sys/gpio number
 static int pinToGpio_neocore [MAX_PIN_COUNT] ={
-   0,        //0
-   6, 2,   //1, 2
-   3, 200,   //3, 4
-   201, 1,   //5, 6
-   203, 12, //7, 8
-   11,  67, //9, 10
-   -1,  64,   //11, 12
-   65,  66,  //13, 14
-   198,  199,  //15, 16
-   4, 5,  //17, 18
-   17, 13,   //19, 20
-   14, 15,    //21, 22
-   16, 7,   //23, 24
-   -1, -1,   //25, 26
-   -1, -1,   //27, 28
-   -1, -1,   //29, 30
-   -1, -1,   //31, 32
-   -1, -1,   //33, 34
-   -1, -1,   //35, 36
-   -1, -1,   //37, 38
-
+    0,         // 0
+    6,     2,  //  1,  2
+    3,   200,  //  3,  4
+    201,   1,  //  5,  6
+    203,  12,  //  7,  8
+    11,   67,  //  9, 10
+    -1,   64,  // 11, 12
+    65,   66,  // 13, 14
+    198, 199,  // 15, 16
+    4,     5,  // 17, 18
+    17,   13,  // 19, 20
+    14,   15,  // 21, 22
+    16,    7,  // 23, 24
+    -1, -1,    // 25, 26
+    -1, -1,    // 27, 28
+    -1, -1,    // 29, 30
+    -1, -1,    // 31, 32
+    -1, -1,    // 33, 34
+    -1, -1,    // 35, 36
+    -1, -1,    // 37, 38
     /* 39~63 */
-   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-
-   /* 64~73 */
-   -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    /* 64~73 */
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 };
 
 
@@ -506,29 +488,29 @@ static int pinTobcm [64] ={
 static int physToGpio_neo [MAX_PIN_COUNT] ={
     -1, 
     /* 24 Pin */
-    -1, -1,   //1, 2
-    12, -1,   //3, 4
-    11, -1,   //5, 6
-    203, 198, //7, 8
-    -1,  199, //9, 10
-    0,   6,   //11, 12
-    2,   -1,  //13, 14
-    3,  200,  //15, 16
-    -1, 201,  //17, 18
-    64, -1,   //19, 20
-    65, 1,    //21, 22
-    66, 67,   //23, 24
+    -1,   -1,  //  1,  2
+    12,   -1,  //  3,  4
+    11,   -1,  //  5,  6
+    203, 198,  //  7,  8
+    -1,  199,  //  9, 10
+    0,     6,  // 11, 12
+    2,    -1,  // 13, 14
+    3,   200,  // 15, 16
+    -1,  201,  // 17, 18
+    64,   -1,  // 19, 20
+    65,    1,  // 21, 22
+    66,   67,  // 23, 24
 
     /* 12 Pin */
-    -1, -1,   //25, 26
-    -1, -1,   //27, 28
-    -1, -1,   //29, 30
-    17, -1,   //31, 32
-    -1, -1,   //33, 34
-    -1, -1,   //35, 36
+    -1, -1,   // 25, 26
+    -1, -1,   // 27, 28
+    -1, -1,   // 29, 30
+    17, -1,   // 31, 32
+    -1, -1,   // 33, 34
+    -1, -1,   // 35, 36
 
     /* UART0 Tx,Rx */
-    4, 5,     //37, 38
+    4, 5,     // 37, 38
 
     /* 39~63 */
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
@@ -543,72 +525,72 @@ static int physToGpio_neo [MAX_PIN_COUNT] ={
 static int physToGpio_neocore [MAX_PIN_COUNT] ={
     -1, 
     /* GPIO-1 24Pin */
-    -1, -1,   //1, 2
-    12, -1,   //3, 4
-    11, -1,   //5, 6
-    203, 198, //7, 8
-    -1,  199, //9, 10
-    0,   6,   //11, 12
-    2,   -1,  //13, 14
-    3,  200,  //15, 16
-    -1, 201,  //17, 18
-    64, -1,   //19, 20
-    65, 1,    //21, 22
-    66, 67,   //23, 24
+    -1,   -1,  //  1,  2
+    12,   -1,  //  3,  4
+    11,   -1,  //  5,  6
+    203, 198,  //  7,  8
+    -1,  199,  //  9, 10
+    0,     6,  // 11, 12
+    2,    -1,  // 13, 14
+    3,   200,  // 15, 16
+    -1,  201,  // 17, 18
+    64,   -1,  // 19, 20
+    65,    1,  // 21, 22
+    66,   67,  // 23, 24
 
 /* GPIO-2 24Pin */
-  -1,  15,   //25, 26  -> 1, 2
-  -1,  16,   //27, 28  -> 3, 4
-  -1,  14,   //29, 30  -> 5, 6
-  -1,  13,   //31, 32  -> 7, 8
-  -1,  -1,   //33, 34  -> 9, 10
-  -1,  -1,   //35, 36  -> 11, 12
-  17,  -1,   //37, 38  -> 13, 14
-  -1,  -1,   //39, 40  -> 15, 16
-  -1,   5,   //41, 42  -> 17, 18
-  -1,   4,   //43, 44  -> 19, 20
-  -1,  -1,   //45, 46  -> 21, 22
-  -1,  -1,   //47, 48  -> 23, 24
+    -1,  15,  // 25, 26  -> 1, 2
+    -1,  16,  // 27, 28  -> 3, 4
+    -1,  14,  // 29, 30  -> 5, 6
+    -1,  13,  // 31, 32  -> 7, 8
+    -1,  -1,  // 33, 34  -> 9, 10
+    -1,  -1,  // 35, 36  -> 11, 12
+    17,  -1,  // 37, 38  -> 13, 14
+    -1,  -1,  // 39, 40  -> 15, 16
+    -1,   5,  // 41, 42  -> 17, 18
+    -1,   4,  // 43, 44  -> 19, 20
+    -1,  -1,  // 45, 46  -> 21, 22
+    -1,  -1,  // 47, 48  -> 23, 24
 
  /* GPIO-3 24Pin */
-  -1,  -1,   //49, 50  -> 1, 2
-  -1,  -1,   //51, 52  -> 3, 4
-  -1,  -1,   //53, 54  -> 5, 6
-  -1,  -1,   //55, 56  -> 7, 8
-  -1,  -1,   //57, 58  -> 9, 10
-  -1,  -1,   //59, 60  -> 11, 12
-  -1,   7,   //61, 62  -> 13, 14
-  -1,  -1,   //63, 64  -> 15, 16
-  -1,  -1,   //65, 66  -> 17, 18
-  -1,  -1,   //67, 68  -> 19, 20
-  -1,  -1,   //69, 70  -> 21, 22
-  -1,  -1,   //71, 72  -> 23, 24
-  -1,        //73
+    -1,  -1,  // 49, 50  -> 1, 2
+    -1,  -1,  // 51, 52  -> 3, 4
+    -1,  -1,  // 53, 54  -> 5, 6
+    -1,  -1,  // 55, 56  -> 7, 8
+    -1,  -1,  // 57, 58  -> 9, 10
+    -1,  -1,  // 59, 60  -> 11, 12
+    -1,   7,  // 61, 62  -> 13, 14
+    -1,  -1,  // 63, 64  -> 15, 16
+    -1,  -1,  // 65, 66  -> 17, 18
+    -1,  -1,  // 67, 68  -> 19, 20
+    -1,  -1,  // 69, 70  -> 21, 22
+    -1,  -1,  // 71, 72  -> 23, 24
+    -1,       // 73
 };
 
 static int physToGpio_m1 [MAX_PIN_COUNT] ={
-    -1, // 0
-    -1, -1, // 1, 2
-    12, -1, // 3, 4
-    11, -1, // 5, 6
-    203, 198, // 7, 8
-    -1, 199, // 9, 10
-    0, 6, //11, 12
-    2, -1, //13, 14
-    3, 200, //15, 16
-    -1, 201, //17, 18
-    64, -1, //19, 20
-    65, 1, //21, 22
-    66, 67, //23, 24
-    -1, 17, //25, 26
-    19, 18, //27, 28
-    20, -1, //29, 30
-    21, 7, //31, 32
-    8, -1, //33, 34
-    16, 13, //35, 36
-    9, 15, //37, 38
-    -1, 14, //39, 40
-    -1, -1, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, //41-> 55
+    -1,   // 0
+    -1,   -1, //  1,  2
+    12,   -1, //  3,  4
+    11,   -1, //  5,  6
+    203, 198, //  7,  8
+    -1,  199, //  9, 10
+    0,     6, // 11, 12
+    2,    -1, // 13, 14
+    3,   200, // 15, 16
+    -1,  201, // 17, 18
+    64,   -1, // 19, 20
+    65,    1, // 21, 22
+    66,   67, // 23, 24
+    -1,   17, // 25, 26
+    19,   18, // 27, 28
+    20,   -1, // 29, 30
+    21,    7, // 31, 32
+    8,    -1, // 33, 34
+    16,   13, // 35, 36
+    9,    15, // 37, 38
+    -1,   14, // 39, 40
+    -1, -1, 4, 5, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // 41-> 55
     -1, -1, -1, -1, -1, -1, -1, -1 // 56-> 63
 
     /* 64~73 */
@@ -617,31 +599,31 @@ static int physToGpio_m1 [MAX_PIN_COUNT] ={
 
 // phys pin number to /sys/gpio number
 static int physToGpio_duo [MAX_PIN_COUNT] ={
-   -1,        //0
- /* 32 Pin */
-   -1, -1,   //1, 2
-   -1, -1,   //3, 4
-   -1, -1,   //5, 6
-   -1, -1,   //7, 8
-   -1, -1,   //9, 10
-   198,363,   //11, 12
-   199,-1,   //13, 14
-   15, -1,   //15, 16
-   16, -1,   //17, 18
-   14, -1,   //19, 20
-   13, 203,  //21, 22
-   12, -1,  //23, 24
-   11, -1,   //25, 26
-   -1, -1,   //27, 28
-   4,  -1,   //29, 30
-   5,  -1,   //31, 32
-   /* ---------nanopi duo end----------- */
+    -1,        // 0
+    /* 32 Pin */
+    -1,   -1,  // 1,   2
+    -1,   -1,  // 3,   4
+    -1,   -1,  // 5,   6
+    -1,   -1,  // 7,   8
+    -1,   -1,  // 9,  10
+    198, 363,  // 11, 12
+    199,  -1,  // 13, 14
+    15,   -1,  // 15, 16
+    16,   -1,  // 17, 18
+    14,   -1,  // 19, 20
+    13,  203,  // 21, 22
+    12,   -1,  // 23, 24
+    11,   -1,  // 25, 26
+    -1,   -1,  // 27, 28
+    4,    -1,  // 29, 30
+    5,    -1,  // 31, 32
+    /* ---------nanopi duo end----------- */
 
-    -1, -1,   //33, 34
-    -1, -1,   //35, 36
+    -1, -1,   // 33, 34
+    -1, -1,   // 35, 36
 
     /* UART0 Tx,Rx */
-    -1, -1,     //37, 38
+    -1, -1,   // 37, 38
 
     /* 39~63 */
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
@@ -654,38 +636,38 @@ static int physToGpio_duo [MAX_PIN_COUNT] ={
 
 // phys pin number to /sys/gpio number
 static int physToGpio_duo2 [MAX_PIN_COUNT] ={
-   -1,        //0
- /* 32 Pin */
-   -1,   5,   //1, 2
-   -1,   4,   //3, 4
-   -1,  -1,   //5, 6
-   -1,  11,   //7, 8
-  363,  12,   //9, 10
-  203,  13,   //11, 12
-   -1,  14,   //13, 14
-   -1,  16,   //15, 16
-   -1,  15,   //17, 18
-   -1, 199,   //19, 20
-   -1, 198,  //21, 22
-   -1,  -1,  //23, 24
-   -1,  -1,   //25, 26
-   -1,  -1,   //27, 28
-   -1,  -1,   //29, 30
-   -1,  -1,   //31, 32
-   /* ---------nanopi duo end----------- */
+    -1,        // 0
+    /* 32 Pin */
+    -1,   5,  //  1, 2
+    -1,   4,  //  3, 4
+    -1,  -1,  //  5, 6
+    -1,  11,  //  7, 8
+    363, 12,  //  9, 10
+    203, 13,  // 11, 12
+    -1,  14,  // 13, 14
+    -1,  16,  // 15, 16
+    -1,  15,  // 17, 18
+    -1, 199,  // 19, 20
+    -1, 198,  // 21, 22
+    -1,  -1,  // 23, 24
+    -1,  -1,  // 25, 26
+    -1,  -1,  // 27, 28
+    -1,  -1,  // 29, 30
+    -1,  -1,  // 31, 32
+    /* ---------nanopi duo end----------- */
 
-    -1, -1,   //33, 34
-    -1, -1,   //35, 36
+     -1, -1,   // 33, 34
+     -1, -1,   // 35, 36
 
-    /* UART0 Tx,Rx */
-    -1, -1,     //37, 38
+     /* UART0 Tx,Rx */
+     -1, -1,   // 37, 38
 
-    /* 39~63 */
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     /* 39~63 */
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 
-    /* 64~73 */
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+     /* 64~73 */
+     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 };
 
 //
@@ -765,28 +747,28 @@ static int syspin_duo2 [MAX_PIN_COUNT] ={
 
 static int physToPin_m1 [MAX_PIN_COUNT] = //return wiringPI pin
 {
-    -1, // 0
-    -1, -1, // 1, 2
-    8, -1, //3, 4
-    9, -1, //5, 6
-    7, 15, //7, 8
-    -1, 16, //9,10
-    0, 1, //11,12
-    2, -1, //13,14
-    3, 4, //15,16
-    -1, 5, //17,18
-    12, -1, //19,20
-    13, 6, //21,22
-    14, 10, //23, 24
-    -1, 11, // 25, 26
+    -1,      // 0
+    -1, -1,  //  1,  2
+    8,  -1,  //  3,  4
+    9,  -1,  //  5,  6
+    7,  15,  //  7,  8
+    -1, 16,  //  9, 10
+    0,   1,  // 11, 12
+    2,  -1,  // 13, 14
+    3,   4,  // 15, 16
+    -1,  5,  // 17, 18
+    12, -1,  // 19, 20
+    13,  6,  // 21, 22
+    14, 10,  // 23, 24
+    -1, 11,  // 25, 26
 
-    30, 31, //27, 28
-    21, -1, //29, 30
-    22, 26, //31, 32
-    23, -1, //33, 34
-    24, 27, //35, 36
-    25, 28, //37, 38
-    -1, 29, //39, 40
+    30, 31,  // 27, 28
+    21, -1,  // 29, 30
+    22, 26,  // 31, 32
+    23, -1,  // 33, 34
+    24, 27,  // 35, 36
+    25, 28,  // 37, 38
+    -1, 29,  // 39, 40
     // Padding:
 
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, // ... 56
@@ -798,28 +780,27 @@ static int physToPin_m1 [MAX_PIN_COUNT] = //return wiringPI pin
 
 static int physToPin_neo [MAX_PIN_COUNT] = //return wiringPI pin
 {
-  -1,        // 0
-  -1,  -1,   // 1, 2
-   8,  -1,   // 3, 4
-   9,  -1,   // 5, 6
-   7,  15,   // 7, 8
-  -1,  16,   // 9, 10
-   0,   1,   //11, 12
-   2,  -1,   //13, 14
-   3,   4,   //15, 16
-  -1,   5,   //17, 18
-  12,  -1,   //19, 20
-  13,   6,   //21, 22
-  14,  10,   //23, 24
+    -1,       //  0
+    -1, -1,   //  1,  2
+    8,  -1,   //  3,  4
+    9,  -1,   //  5,  6
+    7,  15,   //  7,  8
+    -1, 16,   //  9, 10
+    0,   1,   // 11, 12
+    2,  -1,   // 13, 14
+    3,   4,   // 15, 16
+    -1,  5,   // 17, 18
+    12, -1,   // 19, 20
+    13,  6,   // 21, 22
+    14, 10,   // 23, 24
 
-  -1,  -1,   //25, 26
-  -1,  -1,   //27, 28
-  -1,  -1,   //29, 30
-  19,  -1,   //31, 32
-  -1,  -1,   //33, 34
-  -1,  -1,   //35, 36
-
-  17,  18,   //37, 38
+    -1,  -1,  // 25, 26
+    -1,  -1,  // 27, 28
+    -1,  -1,  // 29, 30
+    19,  -1,  // 31, 32
+    -1,  -1,  // 33, 34
+    -1,  -1,  // 35, 36
+    17,  18,  // 37, 38
 
     /* 39~63 */
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
@@ -833,76 +814,75 @@ static int physToPin_neo [MAX_PIN_COUNT] = //return wiringPI pin
 static int physToPin_neocore [MAX_PIN_COUNT] = //return wiringPI pin
 {
 /* GPIO-1 24Pin */
-  -1,        // 0
-  -1,  -1,   // 1, 2  -> 1, 2
-   8,  -1,   // 3, 4  -> 3, 4
-   9,  -1,   // 5, 6  -> 5, 6
-   7,  15,   // 7, 8  -> 7, 8
-  -1,  16,   // 9, 10  -> 9, 10
-   0,   1,   //11, 12  -> 11, 12
-   2,  -1,   //13, 14  -> 13, 14
-   3,   4,   //15, 16  -> 15, 16
-  -1,   5,   //17, 18  -> 17, 18
-  12,  -1,   //19, 20  -> 19, 20
-  13,   6,   //21, 22  -> 21, 22
-  14,  10,   //23, 24  -> 23, 24
+    -1,      //  0
+    -1, -1,  //  1,  2 ->  1,  2
+    8,  -1,  //  3,  4 ->  3,  4
+    9,  -1,  //  5,  6 ->  5,  6
+    7,  15,  //  7,  8 ->  7,  8
+    -1, 16,  //  9, 10 ->  9, 10
+    0,   1,  // 11, 12 -> 11, 12
+    2,  -1,  // 13, 14 -> 13, 14
+    3,   4,  // 15, 16 -> 15, 16
+    -1,  5,  // 17, 18 -> 17, 18
+    12, -1,  // 19, 20 -> 19, 20
+    13,  6,  // 21, 22 -> 21, 22
+    14, 10,  // 23, 24 -> 23, 24
 
-/* GPIO-2 24Pin */
-  -1,  22,   //25, 26  -> 1, 2
-  -1,  23,   //27, 28  -> 3, 4
-  -1,  21,   //29, 30  -> 5, 6
-  -1,  20,   //31, 32  -> 7, 8
-  -1,  -1,   //33, 34  -> 9, 10
-  -1,  -1,   //35, 36  -> 11, 12
-  19,  -1,   //37, 38  -> 13, 14
-  -1,  -1,   //39, 40  -> 15, 16
-  -1,  18,   //41, 42  -> 17, 18
-  -1,  17,   //43, 44  -> 19, 20
-  -1,  -1,   //45, 46  -> 21, 22
-  -1,  -1,   //47, 48  -> 23, 24
+  /* GPIO-2 24Pin */
+    -1,  22,  // 25, 26  ->  1,  2
+    -1,  23,  // 27, 28  ->  3,  4
+    -1,  21,  // 29, 30  ->  5,  6
+    -1,  20,  // 31, 32  ->  7,  8
+    -1,  -1,  // 33, 34  ->  9, 10
+    -1,  -1,  // 35, 36  -> 11, 12
+    19,  -1,  // 37, 38  -> 13, 14
+    -1,  -1,  // 39, 40  -> 15, 16
+    -1,  18,  // 41, 42  -> 17, 18
+    -1,  17,  // 43, 44  -> 19, 20
+    -1,  -1,  // 45, 46  -> 21, 22
+    -1,  -1,  // 47, 48  -> 23, 24
 
- /* GPIO-3 24Pin */
-  -1,  -1,   //49, 50  -> 1, 2
-  -1,  -1,   //51, 52  -> 3, 4
-  -1,  -1,   //53, 54  -> 5, 6
-  -1,  -1,   //55, 56  -> 7, 8
-  -1,  -1,   //57, 58  -> 9, 10
-  -1,  -1,   //59, 60  -> 11, 12
-  -1,  24,   //61, 62  -> 13, 14
-  -1,  -1,   //63, 64  -> 15, 16
-  -1,  -1,   //65, 66  -> 17, 18
-  -1,  -1,   //67, 68  -> 19, 20
-  -1,  -1,   //69, 70  -> 21, 22
-  -1,  -1,   //71, 72  -> 23, 24
-  -1,        //73
+   /* GPIO-3 24Pin */
+    -1,  -1,  // 49, 50  ->  1,  2
+    -1,  -1,  // 51, 52  ->  3,  4
+    -1,  -1,  // 53, 54  ->  5,  6
+    -1,  -1,  // 55, 56  ->  7,  8
+    -1,  -1,  // 57, 58  ->  9, 10
+    -1,  -1,  // 59, 60  -> 11, 12
+    -1,  24,  // 61, 62  -> 13, 14
+    -1,  -1,  // 63, 64  -> 15, 16
+    -1,  -1,  // 65, 66  -> 17, 18
+    -1,  -1,  // 67, 68  -> 19, 20
+    -1,  -1,  // 69, 70  -> 21, 22
+    -1,  -1,  // 71, 72  -> 23, 24
+    -1,       // 73
 };
 
 
 
 static int physToPin_duo [MAX_PIN_COUNT] = //return wiringPI pin //note: same as physToWpi
 {
-  -1,        // 0
-  -1,  -1,   // 1, 2
-  -1,  -1,   // 3, 4
-  -1,  -1,   // 5, 6
-  -1,  -1,   // 7, 8
-  -1,  -1,   // 9, 10
-   8,  -1,   //11, 12
-   9,  -1,   //13, 14
-   7,  -1,   //15, 16
-   0,  -1,   //17, 18
-   2,  -1,   //19, 20
-   3,  16,   //21, 22
-  12,  -1,   //23, 24
-  13,  -1,   //25, 26
-  -1,  -1,   //27, 28
-  14,  -1,   //29, 30
-  15,  -1,   //31, 32
-   /* ---------nanopi duo end----------- */
-  -1,  -1,   //33, 34
-  -1,  -1,   //35, 36
-
-  -1,  -1,   //37, 38
+    -1,       //  0
+    -1,  -1,  //  1,  2
+    -1,  -1,  //  3,  4
+    -1,  -1,  //  5,  6
+    -1,  -1,  //  7,  8
+    -1,  -1,  //  9, 10
+     8,  -1,  // 11, 12
+     9,  -1,  // 13, 14
+     7,  -1,  // 15, 16
+     0,  -1,  // 17, 18
+     2,  -1,  // 19, 20
+     3,  16,  // 21, 22
+    12,  -1,  // 23, 24
+    13,  -1,  // 25, 26
+    -1,  -1,  // 27, 28
+    14,  -1,  // 29, 30
+    15,  -1,  // 31, 32
+     /* ---------nanopi duo end----------- */
+    -1,  -1,  // 33, 34
+    -1,  -1,  // 35, 36
+    -1,  -1,  // 37, 38
 
     /* 39~63 */
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
@@ -914,28 +894,27 @@ static int physToPin_duo [MAX_PIN_COUNT] = //return wiringPI pin //note: same as
 
 static int physToPin_duo2 [MAX_PIN_COUNT] = //return wiringPI pin //note: same as physToWpi
 {
-  -1,        // 0
-  -1,  15,   // 1, 2
-  -1,  14,   // 3, 4
-  -1,  -1,   // 5, 6
-  -1,  13,   // 7, 8
-  -1,  12,   // 9, 10
-  16,   3,   //11, 12
-  -1,   2,   //13, 14
-  -1,   0,   //15, 16
-  -1,   7,   //17, 18
-  -1,   9,   //19, 20
-  -1,   8,   //21, 22
-  -1,  -1,   //23, 24
-  -1,  -1,   //25, 26
-  -1,  -1,   //27, 28
-  -1,  -1,   //29, 30
-  -1,  -1,   //31, 32
-   /* ---------nanopi duo end----------- */
-  -1,  -1,   //33, 34
-  -1,  -1,   //35, 36
-
-  -1,  -1,   //37, 38
+    -1,      //  0
+    -1, 15,  //  1,  2
+    -1, 14,  //  3,  4
+    -1, -1,  //  5,  6
+    -1, 13,  //  7,  8
+    -1, 12,  //  9, 10
+    16,  3,  // 11, 12
+    -1,  2,  // 13, 14
+    -1,  0,  // 15, 16
+    -1,  7,  // 17, 18
+    -1,  9,  // 19, 20
+    -1,  8,  // 21, 22
+    -1, -1,  // 23, 24
+    -1, -1,  // 25, 26
+    -1, -1,  // 27, 28
+    -1, -1,  // 29, 30
+    -1, -1,  // 31, 32
+    /* ---------nanopi duo end----------- */
+    -1, -1,  // 33, 34
+    -1, -1,  // 35, 36
+    -1, -1,  // 37, 38
 
     /* 39~63 */
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
@@ -1548,16 +1527,15 @@ int getAlt(int pin) {
     }
     alt = sunxi_get_gpio_mode(pin);
     return alt;
-
 }
 
 int getAltSilence(int pin) {
     int alt;
 
-  if (pin >= MAX_PIN_COUNT || pin < 0) {
+    if (pin >= MAX_PIN_COUNT || pin < 0) {
         return -1;
-  }
-  
+    }
+
     if (pinToGpio == 0 || physToGpio == 0) {
         return -1;
     }
@@ -1733,78 +1711,72 @@ void pinModeAlt(int pin, int mode) {
  */
 
 void pinMode(int pin, int mode) {
+    struct wiringPiNodeStruct *node = wiringPiNodes;
 
-  struct wiringPiNodeStruct *node = wiringPiNodes;
+    if (wiringPiDebug)
+        printf("Func: %s, Line: %d,pin:%d,mode:%d\n", __func__, __LINE__, pin, mode);
 
-  if (wiringPiDebug)
-    printf("Func: %s, Line: %d,pin:%d,mode:%d\n", __func__, __LINE__, pin, mode);
-
-  if (pinToGpio == 0 || physToGpio == 0) {
-    printf("please call wiringPiSetup first.\n");
-    return;
-  }
-
-  // On-board pin
-    if (pin > 0 && pin < MAX_PIN_COUNT) {
-      if (wiringPiMode == WPI_MODE_PINS) {
-        pin = pinToGpio [pin];
-        if (wiringPiDebug) {
-         printf(">>> pinToGpio[pin] ret %d\n", pin);
-       }
-     } else if (wiringPiMode == WPI_MODE_PHYS) {
-      pin = physToGpio[pin];
-      if (wiringPiDebug) {
-        printf(">>> physToGpio[pin] ret %d\n", pin);
-      }
-    } else if (wiringPiMode == WPI_MODE_GPIO) {                 // pin = pinTobcm[pin]; 
-
-      pin = pin;
-
-      if (wiringPiDebug) {
-        printf(">>> pinTobcm[pin] ret %d\n", pin);
-      }
-
-    } else {
-      if (wiringPiDebug) {
-       printf(">>> unknow wiringPiMode\n");
-     }
-     return;
-   }
-   /*VCC or GND return directly*/ 
-   if (-1 == pin) {
-            //printf("[%s:L%d] the pin:%d is invaild,please check it over!\n", __func__,  __LINE__, pin);
-     return;
-   }
-
-   if (mode == INPUT) {
-      sunxi_set_gpio_mode(pin, INPUT);
-      wiringPinMode = INPUT;
-      return;
-    } else if (mode == OUTPUT) {
-      sunxi_set_gpio_mode(pin, OUTPUT); //gootoomoon_set_mode
-      wiringPinMode = OUTPUT;
-      return;
-    } else if (mode == PWM_OUTPUT) {
-      if (pin != 5) {
-        printf("the pin you choose doesn't support hardware PWM\n");
-        printf("you can select wiringPi pin %d for PWM pin\n", 1);
-        printf("or you can use it in softPwm mode\n");
+    if (pinToGpio == 0 || physToGpio == 0) {
+        printf("please call wiringPiSetup first.\n");
         return;
-      }
-      //printf("you choose the hardware PWM:%d\n", 1);
-      sunxi_set_gpio_mode(pin, PWM_OUTPUT);
-      wiringPinMode = PWM_OUTPUT;
-      return;
-    } else {
-      return;
     }
 
-  } else {
-    if ((node = wiringPiFindNode(pin)) != NULL)
-      node->pinMode(node, pin, mode);
-    return;
-  }
+    // On-board pin
+    if (pin > 0 && pin < MAX_PIN_COUNT) {
+        if (wiringPiMode == WPI_MODE_PINS) {
+            pin = pinToGpio[pin];
+            if (wiringPiDebug) {
+                printf(">>> pinToGpio[pin] ret %d\n", pin);
+            }
+        } else if (wiringPiMode == WPI_MODE_PHYS) {
+            pin = physToGpio[pin];
+            if (wiringPiDebug) {
+                printf(">>> physToGpio[pin] ret %d\n", pin);
+            }
+        } else if (wiringPiMode == WPI_MODE_GPIO) {                 // pin = pinTobcm[pin];
+            // pin = pin;
+            if (wiringPiDebug) {
+                printf(">>> pinTobcm[pin] ret %d\n", pin);
+            }
+        } else {
+            if (wiringPiDebug) {
+                printf(">>> unknow wiringPiMode\n");
+            }
+            return;
+        }
+        /*VCC or GND return directly*/
+        if (-1 == pin) {
+            //printf("[%s:L%d] the pin:%d is invaild,please check it over!\n", __func__,  __LINE__, pin);
+            return;
+        }
 
+        if (mode == INPUT) {
+            sunxi_set_gpio_mode(pin, INPUT);
+            wiringPinMode = INPUT;
+            return;
+        } else if (mode == OUTPUT) {
+            sunxi_set_gpio_mode(pin, OUTPUT); //gootoomoon_set_mode
+            wiringPinMode = OUTPUT;
+            return;
+        } else if (mode == PWM_OUTPUT) {
+            if (pin != 5) {
+                printf("the pin you choose doesn't support hardware PWM\n");
+                printf("you can select wiringPi pin %d for PWM pin\n", 1);
+                printf("or you can use it in softPwm mode\n");
+                return;
+            }
+            //printf("you choose the hardware PWM:%d\n", 1);
+            sunxi_set_gpio_mode(pin, PWM_OUTPUT);
+            wiringPinMode = PWM_OUTPUT;
+            return;
+        } else {
+            return;
+        }
+    } else {
+        if ((node = wiringPiFindNode(pin)) != NULL)
+            node->pinMode(node, pin, mode);
+        return;
+    }
 }
 
 /*
@@ -1842,17 +1814,14 @@ void pullUpDnControl(int pin, int pud) {
             printf("[%s:L%d] the pin:%d is invaild,please check it over!\n", __func__, __LINE__, pin);
             return;
         }
-
         pud &= 3;
         sunxi_pullUpDnControl(pin, pud);
         return;
-    } else // Extension module
-    {
+    } else { // Extension module
         if ((node = wiringPiFindNode(pin)) != NULL)
             node->pullUpDnControl(node, pin, pud);
         return;
     }
-
 }
 
 /*
@@ -1864,23 +1833,18 @@ void pullUpDnControl(int pin, int pud) {
 int digitalRead(int pin) {
     char c;
     struct wiringPiNodeStruct *node = wiringPiNodes;
-    int oldPin = pin;
-
     if (wiringPiDebug)
       printf("Func: %s, Line: %d,pin:%d\n", __func__, __LINE__, pin);
-
     if (pinToGpio == 0 || physToGpio == 0) {
         printf("please call wiringPiSetup first.\n");
         return 0;
     }
 
     if (pin > 0 && pin < MAX_PIN_COUNT) {
-	    if (wiringPiMode == WPI_MODE_GPIO_SYS) // Sys mode
-	    {
+        if (wiringPiMode == WPI_MODE_GPIO_SYS) { // Sys mode
 		    if (wiringPiDebug) {
 			    printf("in digitalRead, wiringPiMode == WPI_MODE_GPIO_SYS\n");
 		    }
-
 		    if (pin == 0) {
 			    //printf("%d %s,%d invalid pin,please check it over.\n",pin,__func__, __LINE__);
 			    return 0;
@@ -1893,7 +1857,6 @@ int digitalRead(int pin) {
 			    return 0;
 		    }
         */
-
 		    if (sysFds [pin] == -1) {
 			    if (wiringPiDebug)
 				    printf("pin %d sysFds -1.%s,%d\n", pin, __func__, __LINE__);
@@ -1921,12 +1884,11 @@ int digitalRead(int pin) {
 		    if (wiringPiDebug) {
 			    printf(">>> pinTobcm[pin] ret %d\n", pin);
 		    }
-
 	    } else {
 		    return LOW;
 	    }
 	    if (-1 == pin) {
-		    printf("[%s:L%d] the pin:%d is invaild,please check it over!\n", __func__, __LINE__, oldPin);
+            printf("[%s:L%d] the pin:%d is invaild,please check it over!\n", __func__, __LINE__, pin);
 		    return LOW;
 	    }
 	    return sunxi_digitalRead(pin);
@@ -1947,32 +1909,31 @@ int digitalReadSilence(int pin) {
     }
 
     if (pin > 0 && pin < MAX_PIN_COUNT) {
-      if (wiringPiMode == WPI_MODE_GPIO_SYS) // Sys mode
-      {
-        if (pin == 0) {
-          return 0;
-        }
-
-        if (sysFds [pin] == -1) {
-          return LOW;
-        }
-        lseek(sysFds [pin], 0L, SEEK_SET);
-        read(sysFds [pin], &c, 1);
-        return (c == '0') ? LOW : HIGH;
-      } else if (wiringPiMode == WPI_MODE_PINS) {
-        pin = pinToGpio [pin];
-      } else if (wiringPiMode == WPI_MODE_PHYS) {
-        pin = physToGpio[pin];
-      } else if (wiringPiMode == WPI_MODE_GPIO) {
+        if (wiringPiMode == WPI_MODE_GPIO_SYS) { // Sys mode
+            if (pin == 0) {
+                return 0;
+            }
+            if (sysFds [pin] == -1) {
+                return LOW;
+            }
+            lseek(sysFds [pin], 0L, SEEK_SET);
+            read(sysFds [pin], &c, 1);
+            return (c == '0') ? LOW : HIGH;
+        } else if (wiringPiMode == WPI_MODE_PINS) {
+            pin = pinToGpio [pin];
+        } else if (wiringPiMode == WPI_MODE_PHYS) {
+            pin = physToGpio[pin];
+        } else if (wiringPiMode == WPI_MODE_GPIO) {
         // pin = pinTobcm[pin]; 
         pin = pin;
-      } else {
-        return LOW;
-      }
-      if (-1 == pin) {
-        return LOW;
-      }
-      return sunxi_digitalRead(pin);
+            // Nothing
+        } else {
+            return LOW;
+        }
+        if (-1 == pin) {
+            return LOW;
+        }
+        return sunxi_digitalRead(pin);
     } else {
         if ((node = wiringPiFindNode(pin)) == NULL)
             return LOW;
@@ -2029,9 +1990,10 @@ void digitalWrite(int pin, int value) {
             pin = pinToGpio [pin];
         else if (wiringPiMode == WPI_MODE_PHYS)
             pin = physToGpio[pin];
-        else if (wiringPiMode == WPI_MODE_GPIO)
+        else if (wiringPiMode == WPI_MODE_GPIO) {
             // pin = pinTobcm[pin];
             pin = pin;
+        }
         else return;
         if (-1 == pin) {
             //printf("[%s:L%d] the pin:%d is invaild,please check it over!\n", __func__,  __LINE__, pin);
@@ -2050,7 +2012,6 @@ void digitalWrite(int pin, int value) {
  *	Set an output PWM value
  *********************************************************************************
  */
-
 void pwmWrite(int pin, int value) {
     struct wiringPiNodeStruct *node = wiringPiNodes;
 
@@ -2059,16 +2020,13 @@ void pwmWrite(int pin, int value) {
         return;
     }
 
-
     uint32_t a_val = 0;
-    if (pwmmode == 1)//sycle
-    {
+    if (pwmmode == 1) { // cycle
         sunxi_pwm_set_mode(1);
     } else {
-        //sunxi_pwm_set_mode(0);
+        // sunxi_pwm_set_mode(0);
     }
-    if (pin < MAX_PIN_NUM) // On-Board Pin needto fix me Jim
-    {
+    if (pin < MAX_PIN_NUM) { // On-Board Pin needto fix me Jim
         if (wiringPiMode == WPI_MODE_PINS)
             pin = pinToGpio [pin];
         else if (wiringPiMode == WPI_MODE_PHYS) {
@@ -2190,19 +2148,14 @@ void digitalWriteByte(int value) {
     }
 
     if (wiringPiMode == WPI_MODE_GPIO_SYS || wiringPiMode == WPI_MODE_GPIO) {
-
         for (pin = 0; pin < 8; ++pin) {
-
             pinMode(pin, OUTPUT);
             delay(1);
             digitalWrite(pinToGpio [pin], value & mask);
             mask <<= 1;
         }
-
     } else if (wiringPiMode == WPI_MODE_PINS) {
-
         for (pin = 0; pin < 8; ++pin) {
-
             pinMode(pin, OUTPUT);
             delay(1);
             digitalWrite(pin, value & mask);
@@ -2217,7 +2170,6 @@ void digitalWriteByte(int value) {
         }
     }
     return;
-
 }
 
 /*
@@ -2240,10 +2192,11 @@ int waitForInterrupt(int pin, int mS) {
         return;
     }
 
-    /**/ if (wiringPiMode == WPI_MODE_PINS)
+    if (wiringPiMode == WPI_MODE_PINS) {
         pin = pinToGpio [pin];
-    else if (wiringPiMode == WPI_MODE_PHYS)
+    } else if (wiringPiMode == WPI_MODE_PHYS) {
         pin = physToGpio [pin];
+    }
 
     if ((fd = sysFds [pin]) == -1)
         return -2;
@@ -2309,7 +2262,7 @@ int wiringPiISR(int pin, int mode, void (*function)(void)) {
     return wiringPiFailure(WPI_FATAL, "wiringPiISR: Not implemented");
     
     if ((pin < 0) || (pin >= MAX_PIN_COUNT))
-        return wiringPiFailure(WPI_FATAL, "wiringPiISR: pin must be 0-%d (%d)\n", MAX_PIN_COUNT-1,pin);
+        return wiringPiFailure(WPI_FATAL, "wiringPiISR: pin must be 0-%d (%d)\n", MAX_PIN_COUNT-1, pin);
 
     /**/ if (wiringPiMode == WPI_MODE_UNINITIALISED)
         return wiringPiFailure(WPI_FATAL, "wiringPiISR: wiringPi has not been initialised. Unable to continue.\n");
@@ -2320,15 +2273,13 @@ int wiringPiISR(int pin, int mode, void (*function)(void)) {
     else
         bcmGpioPin = pin;
 
-
     if (-1 == bcmGpioPin) /**/ {
         printf("[%s:L%d] the pin:%d is invaild,please check it over!\n", __func__, __LINE__, pin);
         return -1;
     }
 
     //if (edge[bcmGpioPin] == -1)
-        return wiringPiFailure(WPI_FATAL, "wiringPiISR: pin not sunpprt on Nano PI M1 (%d,%d)\n", pin, bcmGpioPin);
-    
+    return wiringPiFailure(WPI_FATAL, "wiringPiISR: pin not sunpprt on Nano PI M1 (%d,%d)\n", pin, bcmGpioPin);
 }
 
 /*
@@ -2470,10 +2421,8 @@ int wiringPiSetup(void) {
     //    boardRev = piBoardRev();
 
     // Open the master /dev/memory device
-
     if ((fd = open("/dev/mem", O_RDWR | O_SYNC | O_CLOEXEC)) < 0)
         return wiringPiFailure(WPI_ALMOST, "wiringPiSetup: Unable to open /dev/mem: %s\n", strerror(errno));
-
 
     // GPIO:
     // BLOCK SIZE * 2 increases range to include pwm addresses
@@ -2482,53 +2431,53 @@ int wiringPiSetup(void) {
         return wiringPiFailure(WPI_ALMOST, "wiringPiSetup: mmap (GPIO) failed: %s\n", strerror(errno));
 
     // PWM
-
     pwm = (uint32_t *) mmap(0, BLOCK_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, GPIO_PWM_BP);
     if ((int32_t) pwm == -1)
         return wiringPiFailure(WPI_ALMOST, "wiringPiSetup: mmap (PWM) failed: %s\n", strerror(errno));
 
     // Clock control (needed for PWM)
-
     clk = (uint32_t *) mmap(0, BLOCK_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, CLOCK_BASE_BP);
     if ((int32_t) clk == -1)
         return wiringPiFailure(WPI_ALMOST, "wiringPiSetup: mmap (CLOCK) failed: %s\n", strerror(errno));
 
     // The drive pads
-
     pads = (uint32_t *) mmap(0, BLOCK_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, GPIO_PADS_BP);
     if ((int32_t) pads == -1)
         return wiringPiFailure(WPI_ALMOST, "wiringPiSetup: mmap (PADS) failed: %s\n", strerror(errno));
 
-
-
     initialiseEpoch();
 
     // If we're running on a compute module, then wiringPi pin numbers don't really many anything...
-
     piBoardId(&model, &rev, &mem, &maker, &overVolted);
     wiringPiMode = WPI_MODE_PINS;
 
     int faBoardId = model;
-    if (faBoardId == NanoPi_M1 || faBoardId == NanoPi_M1_Plus || faBoardId == NanoPi_M1_Plus2 || faBoardId == NanoPi_K1_Plus) {
+    if (faBoardId == NanoPi_M1
+            || faBoardId == NanoPi_M1_Plus
+            || faBoardId == NanoPi_M1_Plus2
+            || faBoardId == NanoPi_K1_Plus) {
 	    pinToGpio = pinToGpio_m1;
 	    physToGpio = physToGpio_m1;
 	    physToPin = physToPin_m1;
-		  syspin = syspin_m1;
-    } else if (faBoardId == NanoPi_NEO || faBoardId == NanoPi_NEO_Air || faBoardId == NanoPi_NEO2 || faBoardId == NanoPi_NEO_Plus2) {
+        syspin = syspin_m1;
+    } else if (faBoardId == NanoPi_NEO
+               || faBoardId == NanoPi_NEO_Air
+               || faBoardId == NanoPi_NEO2
+               || faBoardId == NanoPi_NEO_Plus2) {
 	    pinToGpio = pinToGpio_neo;
 	    physToGpio = physToGpio_neo;
 	    physToPin = physToPin_neo;
-      syspin = syspin_neo;
+        syspin = syspin_neo;
     } else if (faBoardId == NanoPi_Duo) {
 	    pinToGpio = pinToGpio_duo;
 	    physToGpio = physToGpio_duo;
 	    physToPin = physToPin_duo;
-		  syspin = syspin_duo;
+        syspin = syspin_duo;
     } else if (faBoardId == NanoPi_Duo2) {
-      pinToGpio = pinToGpio_duo2;
-      physToGpio = physToGpio_duo2;
-      physToPin = physToPin_duo2;
-      syspin = syspin_duo2;
+        pinToGpio = pinToGpio_duo2;
+        physToGpio = physToGpio_duo2;
+        physToPin = physToPin_duo2;
+        syspin = syspin_duo2;
     } else if (faBoardId == NanoPi_NEO_Core || faBoardId == NanoPi_NEO_Core2) {
 	    pinToGpio = pinToGpio_neocore;
 	    physToGpio = physToGpio_neocore;
@@ -2607,11 +2556,17 @@ int wiringPiSetupSys(void) {
 
     piBoardId(&model, &rev, &mem, &maker, &overVolted);
     int faBoardId = model;
-    if (faBoardId == NanoPi_M1 || faBoardId == NanoPi_M1_Plus || faBoardId == NanoPi_M1_Plus2 || faBoardId == NanoPi_K1_Plus) {
+    if (faBoardId == NanoPi_M1
+            || faBoardId == NanoPi_M1_Plus
+            || faBoardId == NanoPi_M1_Plus2
+            || faBoardId == NanoPi_K1_Plus) {
         pinToGpio = pinToGpio_m1;
         physToGpio = physToGpio_m1;
         physToPin = physToPin_m1;
-    } else if (faBoardId == NanoPi_NEO || faBoardId == NanoPi_NEO_Air || faBoardId == NanoPi_NEO2 || faBoardId == NanoPi_NEO_Plus2) {
+    } else if (faBoardId == NanoPi_NEO
+               || faBoardId == NanoPi_NEO_Air
+               || faBoardId == NanoPi_NEO2
+               || faBoardId == NanoPi_NEO_Plus2) {
         pinToGpio = pinToGpio_neo;
         physToGpio = physToGpio_neo;
         physToPin = physToPin_neo;


### PR DESCRIPTION
- Apply better code formatting to keep code easy readable.
- Avoid several warnings by using correct variable types.
- Comment out assignments like `pin=pin`.
- Avoid dead codeblocks.
- Avoid null-pointer possible dereference.
- Use `-j nproc` with `make` command to do multhithreaded builds where it is possible, to speedup build time.