### PR TITLE
NanoPi NEO2 / Armbian has 'sun50iw1p1' in cpuinfo

### DIFF
--- a/wiringPi/boardtype_friendlyelec.c
+++ b/wiringPi/boardtype_friendlyelec.c
@@ -58,7 +58,10 @@ BoardHardwareInfo gAllBoardHardwareInfo[] = {
     {"Allwinnersun8iFamily", 0, NanoPi_R1, "NanoPi-R1", "9(0)"},
 
     // a64
-    {"sun50iw1p1", 0, NanoPi_A64, "NanoPi-A64", "0"},
+    // {"sun50iw1p1", 0, NanoPi_A64, "NanoPi-A64", "0"},
+    
+    // armbian+Neo2
+    {"sun50iw1p1", 4, NanoPi_NEO2, "NanoPi-NEO2", "1(0)"},
 
     //allwinner h5
     // kernel 3.x


### PR DESCRIPTION
Current Armbian Ubuntu 18.04 with NanoPi NEO2

Linux nanopineo2 4.19.38-sunxi64 #5.86 SMP Sun May 12 18:16:25 CEST 2019 aarch64 aarch64 aarch64 GNU/Linux

processor	: 0
Processor	: AArch64 Processor rev 4 (aarch64)
Hardware	: sun50iw1p1
BogoMIPS	: 48.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32 cpuid
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x0
CPU part	: 0xd03
CPU revision	: 4

This patch is required for 'gpio' to work.